### PR TITLE
Fix blank block for included symbols

### DIFF
--- a/markup/static/scss/common.scss
+++ b/markup/static/scss/common.scss
@@ -5,7 +5,17 @@ html, body {
 }
 
 .page {
-    
+
+    & > svg {
+        border: 0 !important;
+        clip: rect(0 0 0 0) !important;
+        height: 1px !important;
+        margin: -1px !important;
+        overflow: hidden !important;
+        padding: 0 !important;
+        position: absolute !important;
+        width: 1px !important;
+    }
 }
 
 .page__wrapper {


### PR DESCRIPTION
From this ref: https://github.com/Hiswe/gulp-svg-symbols/issues/23#issuecomment-162777369

Similarly for other css preprocessors.
